### PR TITLE
fix: Use RM client type to pass rego rules

### DIFF
--- a/os-resource/go.mod
+++ b/os-resource/go.mod
@@ -6,7 +6,7 @@ module github.com/open-edge-platform/infra-managers/os-resource
 go 1.24.1
 
 require (
-	github.com/open-edge-platform/infra-core/inventory/v2 v2.26.1
+	github.com/open-edge-platform/infra-core/inventory/v2 v2.26.3-0.20250611155559-8a62ff9d844d
 	github.com/open-edge-platform/orch-library/go v0.6.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0

--- a/os-resource/go.sum
+++ b/os-resource/go.sum
@@ -204,8 +204,8 @@ github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c h1:cqn374
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/open-edge-platform/infra-core/inventory/v2 v2.26.1 h1:36vSSEN1wlucqKBMMI0ekC8Ng0TKH9pfERUVou8Wm8Y=
-github.com/open-edge-platform/infra-core/inventory/v2 v2.26.1/go.mod h1:/bg3cDaZgXU88DOzGLJSkbK4ETpwibhmJnhkpvid7v0=
+github.com/open-edge-platform/infra-core/inventory/v2 v2.26.3-0.20250611155559-8a62ff9d844d h1:GZu3IBlQ5cmDdxSXYZE+Ac2BW09pUvh8exfl5DmsVlo=
+github.com/open-edge-platform/infra-core/inventory/v2 v2.26.3-0.20250611155559-8a62ff9d844d/go.mod h1:/bg3cDaZgXU88DOzGLJSkbK4ETpwibhmJnhkpvid7v0=
 github.com/open-edge-platform/orch-library/go v0.6.1 h1:IGR2ic73f3obnhlxTRfHcyYMbPbYu7BSqa9UYyEZ78Q=
 github.com/open-edge-platform/orch-library/go v0.6.1/go.mod h1:3Tes/GJfwYbnQa/1scbKiLbjZrL4fJEouFk28oo5/c8=
 github.com/open-edge-platform/orch-library/go/dazl v0.5.4 h1:Rx/bSAZiLjEEBjUiJEzBvT0fQv5huT5FQ2Ke3IMUhiE=

--- a/os-resource/internal/invclient/invclient.go
+++ b/os-resource/internal/invclient/invclient.go
@@ -67,7 +67,7 @@ func NewInventoryClient(
 		EnableRegisterRetry:       false,
 		AbortOnUnknownClientError: true,
 		// TODO: Use dedicated client type: ITEP-14459
-		ClientKind:    inv_v1.ClientKind_CLIENT_KIND_API,
+		ClientKind:    inv_v1.ClientKind_CLIENT_KIND_RESOURCE_MANAGER,
 		ResourceKinds: kinds,
 		EnableTracing: enableTracing,
 		EnableMetrics: enableMetrics,

--- a/os-resource/internal/testing/testing_utils.go
+++ b/os-resource/internal/testing/testing_utils.go
@@ -20,8 +20,8 @@ var (
 func CreateInventoryClientForTesting() {
 	var err error
 	InvClient, err = invclient.NewOSRMInventoryClient(
-		inv_testing.TestClients[inv_testing.APIClient].GetTenantAwareInventoryClient(),
-		inv_testing.TestClientsEvents[inv_testing.APIClient], nil)
+		inv_testing.TestClients[inv_testing.RMClient].GetTenantAwareInventoryClient(),
+		inv_testing.TestClientsEvents[inv_testing.RMClient], nil)
 	if err != nil {
 		zlog.Fatal().Err(err).Msg("Cannot create Inventory client")
 	}
@@ -30,6 +30,6 @@ func CreateInventoryClientForTesting() {
 func DeleteInventoryClientForTesting() {
 	InvClient.Close()
 	time.Sleep(1 * time.Second)
-	delete(inv_testing.TestClients, inv_testing.APIClient)
-	delete(inv_testing.TestClientsEvents, inv_testing.APIClient)
+	delete(inv_testing.TestClients, inv_testing.RMClient)
+	delete(inv_testing.TestClientsEvents, inv_testing.RMClient)
 }


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

Changes client type to adjust to the newest rego rules in infra-core.

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Covered with unit tests

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
