### PR TITLE
Update pre-merge.yml update orch-ci version

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         project_folder: ${{ fromJson(needs.pre-checks.outputs.filtered_projects) }}
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@cd3e9a8d77db98ea1b3001fd879bdf5a56baa5e7  # 2026.1.1
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee  # 2026.1.1
     with:
       orch_ci_repo_ref: 3712c26c7ae6e8b3cc53af6e9e6bd8d47dc61420
       bootstrap_tools: "all,golangci-lint2"


### PR DESCRIPTION
This pull request updates the referenced version of the shared CI workflow in the `.github/workflows/pre-merge.yml` file. The new reference points to a more recent commit of the `open-edge-platform/orch-ci` workflow.

CI/CD pipeline update:

* Updated the `pre-merge.yml` workflow to use `open-edge-platform/orch-ci/.github/workflows/pre-merge.yml` at commit `bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee` instead of the previous commit, ensuring the latest workflow improvements and fixes are included.