### PR TITLE
Update pre-merge.yml remove orch-ci reference

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -91,7 +91,6 @@ jobs:
         project_folder: ${{ fromJson(needs.pre-checks.outputs.filtered_projects) }}
     uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee  # 2026.1.1
     with:
-      orch_ci_repo_ref: 3712c26c7ae6e8b3cc53af6e9e6bd8d47dc61420
       bootstrap_tools: "all,golangci-lint2"
       run_security_scans: true
       run_version_check: true


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/pre-merge.yml` file, specifically by removing the `orch_ci_repo_ref` input from the workflow configuration. This streamlines the workflow setup and relies on the default repository reference.

- CI/CD Workflow Update:
  * Removed the `orch_ci_repo_ref` input from the `pre-merge.yml` workflow configuration, simplifying the workflow and using the default reference instead.