### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -28,6 +30,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -45,6 +49,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -62,6 +68,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -79,6 +87,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -96,6 +106,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -114,3 +126,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to introduce a cooldown period for Dependabot updates across multiple package ecosystems. The cooldown setting enforces a 7-day waiting period between update pull requests, which helps reduce noise and manage update frequency more effectively.

Configuration changes:

* Added a `cooldown` section with `default-days: 7` to each package ecosystem's configuration in `.github/dependabot.yml`, ensuring that Dependabot waits at least 7 days before creating new pull requests for updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R14-R15) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R33-R34) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R52-R53) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R71-R72) [[5]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R90-R91) [[6]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R109-R110) [[7]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R129-R130)