### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-attestationstatus.yml
+++ b/.github/workflows/post-merge-attestationstatus.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "attestationstatus/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-host.yml
+++ b/.github/workflows/post-merge-host.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "host/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-maintenance.yml
+++ b/.github/workflows/post-merge-maintenance.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "maintenance/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-networking.yml
+++ b/.github/workflows/post-merge-networking.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "networking/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-os-resource.yml
+++ b/.github/workflows/post-merge-os-resource.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "os-resource/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-telemetry.yml
+++ b/.github/workflows/post-merge-telemetry.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "telemetry/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to trigger on new Git tags, in addition to the existing triggers. The main change is the addition of a `tags` filter, allowing these workflows to run when a tag is pushed that matches any pattern.

Workflow trigger improvements:

* Added a `tags` filter with a wildcard (`'*'`) to the `on` section of the following workflow files, enabling them to trigger on any new tag:
  - `.github/workflows/post-merge-attestationstatus.yml`
  - `.github/workflows/post-merge-host.yml`
  - `.github/workflows/post-merge-maintenance.yml`
  - `.github/workflows/post-merge-networking.yml`
  - `.github/workflows/post-merge-os-resource.yml`
  - `.github/workflows/post-merge-telemetry.yml`