### PR TITLE
Remove trigger on tag from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge-attestationstatus.yml
+++ b/.github/workflows/post-merge-attestationstatus.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "attestationstatus/**"
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-host.yml
+++ b/.github/workflows/post-merge-host.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "host/**"
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-maintenance.yml
+++ b/.github/workflows/post-merge-maintenance.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "maintenance/**"
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-networking.yml
+++ b/.github/workflows/post-merge-networking.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "networking/**"
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-os-resource.yml
+++ b/.github/workflows/post-merge-os-resource.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "os-resource/**"
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-telemetry.yml
+++ b/.github/workflows/post-merge-telemetry.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "telemetry/**"
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files by removing the trigger for workflow runs on Git tags. The workflows will now only run on pushes to branches and manual dispatch, not on tag creation.

Workflow trigger updates:

* Removed the `tags` trigger from the following workflow files, so these workflows will no longer run when tags are pushed:
  - `.github/workflows/post-merge-attestationstatus.yml`
  - `.github/workflows/post-merge-host.yml`
  - `.github/workflows/post-merge-maintenance.yml`
  - `.github/workflows/post-merge-networking.yml`
  - `.github/workflows/post-merge-os-resource.yml`
  - `.github/workflows/post-merge-telemetry.yml`